### PR TITLE
generate sourcesJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,3 +49,6 @@ publishing {
     }
 }
 
+java {
+    withSourcesJar()
+}


### PR DESCRIPTION
providing a sourcesJar would make it simpler to use this lib, as this will show javadoc, comments and the PublicApi annotation in the project