### PR TITLE
Calling Graph.connect using two GraphObjects that don't have a graph set, causes a crash

### DIFF
--- a/src/main/java/dev/gigaherz/graph3/Graph.java
+++ b/src/main/java/dev/gigaherz/graph3/Graph.java
@@ -52,6 +52,8 @@ public class Graph<T extends Mergeable<T>>
             target = graphFactory.get();
             if (contextDataFactory != null)
                 target.contextData = contextDataFactory.create(target);
+            target.addNode(object1);
+            target.addNode(object2);
         }
 
         target.addSingleEdge(object1, object2);


### PR DESCRIPTION
Fixes #4 