### PR TITLE
Change Mergeable#copy() to Mergable#splitFor to split contexts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'java'
 
-version = "3.0.7"
+version = "3.1.0"
 group= "dev.gigaherz.graph" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 ext {
     archivesBaseName = "GraphLib3"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'java'
 
-version = "3.1.0"
+version = "3.0.8"
 group= "dev.gigaherz.graph" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 ext {
     archivesBaseName = "GraphLib3"

--- a/src/main/java/dev/gigaherz/graph3/Graph.java
+++ b/src/main/java/dev/gigaherz/graph3/Graph.java
@@ -389,7 +389,8 @@ public class Graph<T extends Mergeable<T>>
 
     private void splitAfterRemoval()
     {
-        if (nodeList.size() == 0)
+        int nodeCount = nodeList.size();
+        if (nodeCount == 0)
             return;
 
         Set<Node<T>> remaining = Sets.newHashSet(nodeList);
@@ -426,6 +427,8 @@ public class Graph<T extends Mergeable<T>>
             }
         }
 
+        List<Graph<T>> newGraphs = contextData != null ? new ArrayList<>() : null;
+
         // If anything remains unseen, it means it's on a disconnected subgraph
         while (remaining.size() > 0)
         {
@@ -435,6 +438,10 @@ public class Graph<T extends Mergeable<T>>
             remaining.remove(node);
 
             Graph<T> newGraph = new Graph<>();
+
+            if (newGraphs != null)
+                newGraphs.add(newGraph);
+
             while (succ.size() > 0)
             {
                 Node<T> c = succ.poll();
@@ -469,13 +476,16 @@ public class Graph<T extends Mergeable<T>>
                 c.getObject().setGraph(newGraph);
             }
 
-            // Split the context across both graphs.
-            if (contextData != null) {
-                newGraph.contextData = contextData.splitFor(newGraph, this);
-                contextData = contextData.splitFor(this, newGraph);
+            verify();
+        }
+
+        if (newGraphs != null)
+        {
+            for (var graph : newGraphs) {
+                graph.contextData = contextData.splitFor(graph.nodeList.size(), nodeCount);
             }
 
-            verify();
+            contextData = contextData.splitFor(nodeList.size(), nodeCount);
         }
 
         verify();

--- a/src/main/java/dev/gigaherz/graph3/Graph.java
+++ b/src/main/java/dev/gigaherz/graph3/Graph.java
@@ -481,11 +481,16 @@ public class Graph<T extends Mergeable<T>>
 
         if (newGraphs != null)
         {
-            for (var graph : newGraphs) {
-                graph.contextData = contextData.splitFor(graph.nodeList.size(), nodeCount);
+            int graphCount = newGraphs.size() + 1;
+
+            for (int i = 0; i < newGraphs.size(); i++)
+            {
+                var graph = newGraphs.get(i);
+
+                graph.contextData = contextData.splitFor(graph.nodeList.size(), nodeCount, i, graphCount);
             }
 
-            contextData = contextData.splitFor(nodeList.size(), nodeCount);
+            contextData = contextData.splitFor(nodeList.size(), nodeCount, graphCount - 1, graphCount);
         }
 
         verify();

--- a/src/main/java/dev/gigaherz/graph3/Graph.java
+++ b/src/main/java/dev/gigaherz/graph3/Graph.java
@@ -435,8 +435,6 @@ public class Graph<T extends Mergeable<T>>
             remaining.remove(node);
 
             Graph<T> newGraph = new Graph<>();
-            if (contextData != null)
-                newGraph.contextData = contextData.copy();
             while (succ.size() > 0)
             {
                 Node<T> c = succ.poll();
@@ -469,6 +467,12 @@ public class Graph<T extends Mergeable<T>>
                 newGraph.objects.put(c.getObject(), c);
                 c.owner = newGraph;
                 c.getObject().setGraph(newGraph);
+            }
+
+            // Split the context across both graphs.
+            if (contextData != null) {
+                newGraph.contextData = contextData.splitFor(newGraph, this);
+                contextData = contextData.splitFor(this, newGraph);
             }
 
             verify();

--- a/src/main/java/dev/gigaherz/graph3/Mergeable.java
+++ b/src/main/java/dev/gigaherz/graph3/Mergeable.java
@@ -3,7 +3,7 @@ package dev.gigaherz.graph3;
 public interface Mergeable<T extends Mergeable<T>>
 {
     T mergeWith(T other);
-    T splitFor(Graph<T> selfGraph, Graph<T> otherGraph);
+    T splitFor(int selfNodeCount, int totalNodeCount);
 
     @PublicApi
     Dummy DUMMY = new Dummy();
@@ -19,7 +19,7 @@ public interface Mergeable<T extends Mergeable<T>>
         }
 
         @Override
-        public Dummy splitFor(Graph<Dummy> selfGraph, Graph<Dummy> otherGraph) {
+        public Dummy splitFor(int selfNodeCount, int totalNodeCount) {
             return this;
         }
     }

--- a/src/main/java/dev/gigaherz/graph3/Mergeable.java
+++ b/src/main/java/dev/gigaherz/graph3/Mergeable.java
@@ -3,7 +3,7 @@ package dev.gigaherz.graph3;
 public interface Mergeable<T extends Mergeable<T>>
 {
     T mergeWith(T other);
-    T copy();
+    T splitFor(Graph<T> selfGraph, Graph<T> otherGraph);
 
     @PublicApi
     Dummy DUMMY = new Dummy();
@@ -19,8 +19,7 @@ public interface Mergeable<T extends Mergeable<T>>
         }
 
         @Override
-        public Dummy copy()
-        {
+        public Dummy splitFor(Graph<Dummy> selfGraph, Graph<Dummy> otherGraph) {
             return this;
         }
     }

--- a/src/main/java/dev/gigaherz/graph3/Mergeable.java
+++ b/src/main/java/dev/gigaherz/graph3/Mergeable.java
@@ -3,7 +3,19 @@ package dev.gigaherz.graph3;
 public interface Mergeable<T extends Mergeable<T>>
 {
     T mergeWith(T other);
-    T splitFor(int selfNodeCount, int totalNodeCount);
+    T copy();
+
+    /**
+     * Split the context into multiple parts when a graph is split.
+     * @param selfNodeCount The number of nodes in this part of the graph.
+     * @param totalNodeCount The number of nodes in the graph before the split.
+     * @param graphIndex This graph's index in the split (0 - `graphCount`)
+     * @param graphCount The number of graphs that have been created as a result of the split.
+     * @return A new context that represents the split part of the graph.
+     */
+    default T splitFor(int selfNodeCount, int totalNodeCount, int graphIndex, int graphCount) {
+        return copy();
+    }
 
     @PublicApi
     Dummy DUMMY = new Dummy();
@@ -19,7 +31,7 @@ public interface Mergeable<T extends Mergeable<T>>
         }
 
         @Override
-        public Dummy splitFor(int selfNodeCount, int totalNodeCount) {
+        public Dummy copy() {
             return this;
         }
     }


### PR DESCRIPTION
This enables contexts to be split across both graphs (for example an energy buffer being split across both disconnected sides)